### PR TITLE
Fix default attributes for InfrastructureGatewayProfile

### DIFF
--- a/vspkgenerator/vanilla/go/__attributes_defaults/attrs_defaults.ini
+++ b/vspkgenerator/vanilla/go/__attributes_defaults/attrs_defaults.ini
@@ -60,10 +60,8 @@ Personality                    = "VRSG"
 [InfrastructureGatewayProfile]
 DatapathSyncTimeout            = 1000
 DeadTimer                      = "ONE_HOUR"
-FlowEvictionThreshold          = 2500
 RemoteLogMode                  = "DISABLED"
 SystemSyncScheduler            = "0 0 * * 0"
-SystemSyncWindow               = "ONE_HOUR"
 UseTwoFactor                   = true
 UpgradeAction                  = "NONE"
 StatsCollectorPort             = 29090


### PR DESCRIPTION
The defaults for InfrastructureGatewayProfile added two values which are not attributes of an InfrastructureGatewayProfile. This caused the vspk-go to not build/install properly (basically, become unusable.

This PR fixes that.

Please regenerate the vspk-go as well (and rerelease it with 4.0.5 tag, if possible)

Thanks!