### PR TITLE
vspk-vro and vspk-java 4.0.6 #2

### DIFF
--- a/vspkgenerator/vanilla/java/__attributes_defaults/attrs_defaults.ini
+++ b/vspkgenerator/vanilla/java/__attributes_defaults/attrs_defaults.ini
@@ -112,7 +112,6 @@ multicast                      = Multicast.INHERITED
 [TCA]
 metric                         = Metric.BYTES_IN
 type                           = Type.ROLLING_AVERAGE
-scope                          = Scope.LOCAL
 
 [Tier]
 type                           = Type.STANDARD

--- a/vspkgenerator/vanilla/vro/__attributes_defaults/attrs_defaults.ini
+++ b/vspkgenerator/vanilla/vro/__attributes_defaults/attrs_defaults.ini
@@ -112,7 +112,6 @@ multicast                      = SubnetTemplateMulticast.INHERITED
 [TCA]
 metric                         = TCAMetric.BYTES_IN
 type                           = TCAType.ROLLING_AVERAGE
-scope                          = TCAScope.LOCAL
 
 [Tier]
 type                           = TierType.STANDARD


### PR DESCRIPTION
Removed default value for the scope variable in the TCA entity.