### PR TITLE
Fix vspk-go defaults for TCA

### DIFF
--- a/vspkgenerator/vanilla/go/__attributes_defaults/attrs_defaults.ini
+++ b/vspkgenerator/vanilla/go/__attributes_defaults/attrs_defaults.ini
@@ -113,7 +113,6 @@ Multicast                      = "INHERITED"
 [TCA]
 Metric                         = "BYTES_IN"
 Type                           = "ROLLING_AVERAGE"
-Scope                          = "LOCAL"
 
 [Tier]
 Type                           = "STANDARD"


### PR DESCRIPTION
Breaks VSPK-GO because scope is not present in TCA (anymore)