### PR TITLE
Fixing attr defaults

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     name='vspkgenerator',
     packages=find_packages(exclude=['*tests*']),
     include_package_data=True,
-    version='1.4.2',
+    version='1.4.3',
     description='VSPK Generator',
     author='Nuage Networks',
     author_email='opensource@nuagenetworks.net',

--- a/vspkgenerator/vanilla/csharp/__attributes_defaults/attrs_defaults.ini
+++ b/vspkgenerator/vanilla/csharp/__attributes_defaults/attrs_defaults.ini
@@ -1,12 +1,6 @@
 [AddressRange]
 DHCPPoolType                   = EDHCPPoolType.BRIDGE
 
-[ApplicationService]
-direction                      = EDirection.REFLEXIVE
-DSCP                           = "*"
-etherType                      = "0x0800"
-protocol                       = "6"
-
 [Bootstrap]
 status                         = EStatus.INACTIVE
 
@@ -46,9 +40,6 @@ permittedAction                = EPermittedAction.USE
 DHCPLeaseInterval              = 24L
 floatingIPsQuota               = 100L
 
-[FlowSecurityPolicy]
-action                         = EAction.FORWARD
-
 [Gateway]
 personality                    = EPersonality.VRSG
 
@@ -58,15 +49,10 @@ personality                    = EPersonality.VRSG
 [InfrastructureGatewayProfile]
 datapathSyncTimeout            = 1000L
 remoteLogMode                  = ERemoteLogMode.DISABLED
-systemSyncScheduler            = "0 0 * * 0"
+systemSyncScheduler            = "0 0 * * *"
 useTwoFactor                   = true
 upgradeAction                  = EUpgradeAction.NONE
 statsCollectorPort             = 29090L
-
-[InfrastructurePortProfile]
-duplex                         = EDuplex.FULL
-speed                          = ESpeed.AUTONEGOTIATE
-mtu                            = 1500L
 
 [L2Domain]
 maintenanceMode                = EMaintenanceMode.DISABLED
@@ -76,10 +62,6 @@ timeZoneID                     = "UTC"
 
 [EnterpriseNetwork]
 IPType                         = EIPType.IPV4
-
-[NSG]
-configurationReloadState       = "UNKNOWN"
-configurationStatus            = "UNKNOWN"
 
 [PolicyGroup]
 type                           = EType.SOFTWARE

--- a/vspkgenerator/vanilla/go/__attributes_defaults/attrs_defaults.ini
+++ b/vspkgenerator/vanilla/go/__attributes_defaults/attrs_defaults.ini
@@ -1,21 +1,14 @@
 [AddressRange]
 DHCPPoolType                   = "BRIDGE"
 
-[ApplicationService]
-Direction                      = "REFLEXIVE"
-DSCP                           = "*"
-EtherType                      = "0x0800"
-Protocol                       = "6"
-
 [Bootstrap]
 Status                         = "INACTIVE"
 
 [Domain]
 MaintenanceMode                = "DISABLED"
 TunnelType                     = "DC_DEFAULT"
-ApplicationDeploymentPolicy    = "ZONE"
 DHCPBehavior                   = "CONSUME"
-PATEnabled                     = "INHERITED"
+PATEnabled                     = "DISABLED"
 
 [IngressACLEntryTemplate]
 LocationType                   = "ANY"
@@ -48,28 +41,11 @@ PermittedAction                = "USE"
 DHCPLeaseInterval              = 24
 FloatingIPsQuota               = 100
 
-[FlowSecurityPolicy]
-Action                         = "FORWARD"
-
 [Gateway]
 Personality                    = "VRSG"
 
 [GatewayTemplate]
 Personality                    = "VRSG"
-
-[InfrastructureGatewayProfile]
-DatapathSyncTimeout            = 1000
-DeadTimer                      = "ONE_HOUR"
-RemoteLogMode                  = "DISABLED"
-SystemSyncScheduler            = "0 0 * * 0"
-UseTwoFactor                   = true
-UpgradeAction                  = "NONE"
-StatsCollectorPort             = 29090
-
-[InfrastructurePortProfile]
-Duplex                         = "FULL"
-Speed                          = "AUTONEGOTIATE"
-Mtu                            = 1500
 
 [L2Domain]
 MaintenanceMode                = "DISABLED"
@@ -79,10 +55,6 @@ TimeZoneID                     = "UTC"
 
 [EnterpriseNetwork]
 IPType                         = "IPV4"
-
-[NSG]
-ConfigurationReloadState       = "UNKNOWN"
-ConfigurationStatus            = "UNKNOWN"
 
 [PolicyGroup]
 Type                           = "SOFTWARE"

--- a/vspkgenerator/vanilla/java/__attributes_defaults/attrs_defaults.ini
+++ b/vspkgenerator/vanilla/java/__attributes_defaults/attrs_defaults.ini
@@ -1,12 +1,6 @@
 [AddressRange]
 DHCPPoolType                   = DHCPPoolType.BRIDGE
 
-[ApplicationService]
-direction                      = Direction.REFLEXIVE
-DSCP                           = "*"
-etherType                      = "0x0800"
-protocol                       = "6"
-
 [Bootstrap]
 status                         = Status.INACTIVE
 
@@ -46,9 +40,6 @@ permittedAction                = PermittedAction.USE
 DHCPLeaseInterval              = 24L
 floatingIPsQuota               = 100L
 
-[FlowSecurityPolicy]
-action                         = Action.FORWARD
-
 [Gateway]
 personality                    = Personality.VRSG
 
@@ -58,15 +49,10 @@ personality                    = Personality.VRSG
 [InfrastructureGatewayProfile]
 datapathSyncTimeout            = 1000L
 remoteLogMode                  = RemoteLogMode.DISABLED
-systemSyncScheduler            = "0 0 * * 0"
+systemSyncScheduler            = "0 0 * * *"
 useTwoFactor                   = true
 upgradeAction                  = UpgradeAction.NONE
 statsCollectorPort             = 29090L
-
-[InfrastructurePortProfile]
-duplex                         = Duplex.FULL
-speed                          = Speed.AUTONEGOTIATE
-mtu                            = 1500L
 
 [L2Domain]
 maintenanceMode                = MaintenanceMode.DISABLED
@@ -76,10 +62,6 @@ timeZoneID                     = "UTC"
 
 [EnterpriseNetwork]
 IPType                         = IPType.IPV4
-
-[NSG]
-configurationReloadState       = "UNKNOWN"
-configurationStatus            = "UNKNOWN"
 
 [PolicyGroup]
 type                           = Type.SOFTWARE

--- a/vspkgenerator/vanilla/objj/__attributes_defaults/attrs_defaults.ini
+++ b/vspkgenerator/vanilla/objj/__attributes_defaults/attrs_defaults.ini
@@ -15,7 +15,7 @@ maintenanceMode                = @"DISABLED"
 tunnelType                     = @"DC_DEFAULT"
 applicationDeploymentPolicy    = @"ZONE"
 DHCPBehavior                   = @"CONSUME"
-PATEnabled                     = @"INHERITED"
+PATEnabled                     = @"DISABLED"
 
 [NUIngressACLEntryTemplate]
 locationType                   = @"ANY"

--- a/vspkgenerator/vanilla/python/__attributes_defaults/attrs_defaults.ini
+++ b/vspkgenerator/vanilla/python/__attributes_defaults/attrs_defaults.ini
@@ -1,21 +1,14 @@
 [NUAddressRange]
 dhcp_pool_type                     = BRIDGE
 
-[NUApplicationService]
-direction                          = REFLEXIVE
-dscp                               = *
-ether_type                         = 0x0800
-protocol                           = 6
-
 [NUBootstrap]
 status                             = INACTIVE
 
 [NUDomain]
 maintenance_mode                   = DISABLED
 tunnel_type                        = DC_DEFAULT
-application_deployment_policy      = ZONE
 dhcp_behavior                      = CONSUME
-pat_enabled                        = INHERITED
+pat_enabled                        = DISABLED
 
 [NUIngressACLTemplate]
 default_allow_ip                   = False
@@ -61,12 +54,6 @@ permitted_action                   = USE
 dhcp_lease_interval                = 24
 floating_ips_quota                 = 100
 
-[NUFlowForwardingPolicy]
-redirection_target_type            = GENERIC
-
-[NUFlowSecurityPolicy]
-action                             = FORWARD
-
 [NUGateway]
 personality                        = VRSG
 
@@ -75,21 +62,6 @@ personality                        = VRSG
 
 [NUGroup]
 private                            = False
-
-[NUInfrastructureGatewayProfile]
-datapath_sync_timeout              = 1000
-flow_eviction_threshold            = 2500
-probe_interval                     = 5000
-remote_log_mode                    = DISABLED
-system_sync_scheduler              = 0 0 * * 0
-two_factor_authentication_enabled  = True
-upgrade_action                     = NONE
-stats_collector_port               = 39090
-
-[NUInfrastructurePortProfile]
-duplex                             = FULL
-speed                              = AUTONEGOTIATE
-mtu                                = 1500
 
 [NUL2Domain]
 maintenance_mode                   = DISABLED
@@ -100,12 +72,8 @@ time_zone_id                       = UTC
 [NUEnterpriseNetwork]
 ip_type                            = IPV4
 
-[NUNSG]
-configuration_reload_state         = UNKNOWN
-configuration_status               = UNKNOWN
-
 [NUPermission]
-action                             = READ
+permitted_action                   = READ
 
 [NUPolicyGroup]
 type                               = SOFTWARE
@@ -135,7 +103,6 @@ ip_type                            = IPV4
 multicast                          = INHERITED
 maintenance_mode                   = DISABLED
 pat_enabled                        = INHERITED
-default_action                     = USE_UNDERLAY
 
 [NUSubnetTemplate]
 ip_type                            = IPV4

--- a/vspkgenerator/vanilla/vro/__attributes_defaults/attrs_defaults.ini
+++ b/vspkgenerator/vanilla/vro/__attributes_defaults/attrs_defaults.ini
@@ -14,7 +14,7 @@ status                         = BootstrapStatus.INACTIVE
 maintenanceMode                = DomainMaintenanceMode.DISABLED
 tunnelType                     = DomainTunnelType.DC_DEFAULT
 DHCPBehavior                   = DomainDHCPBehavior.CONSUME
-PATEnabled                     = DomainPATEnabled.INHERITED
+PATEnabled                     = DomainPATEnabled.DISABLED
 
 [IngressACLEntryTemplate]
 locationType                   = IngressACLEntryTemplateLocationType.ANY

--- a/vspkgenerator/vanilla/vro/__attributes_defaults/attrs_defaults.ini
+++ b/vspkgenerator/vanilla/vro/__attributes_defaults/attrs_defaults.ini
@@ -1,12 +1,6 @@
 [AddressRange]
 DHCPPoolType                   = AddressRangeDHCPPoolType.BRIDGE
 
-[ApplicationService]
-direction                      = ApplicationServiceDirection.REFLEXIVE
-DSCP                           = "*"
-etherType                      = "0x0800"
-protocol                       = "6"
-
 [Bootstrap]
 status                         = BootstrapStatus.INACTIVE
 
@@ -47,9 +41,6 @@ permittedAction                = EnterprisePermissionPermittedAction.USE
 DHCPLeaseInterval              = 24L
 floatingIPsQuota               = 100L
 
-[FlowSecurityPolicy]
-action                         = FlowSecurityPolicyAction.FORWARD
-
 [Gateway]
 personality                    = GatewayPersonality.VRSG
 
@@ -59,15 +50,10 @@ personality                    = GatewayTemplatePersonality.VRSG
 [InfrastructureGatewayProfile]
 datapathSyncTimeout            = 1000L
 remoteLogMode                  = InfrastructureGatewayProfileRemoteLogMode.DISABLED
-systemSyncScheduler            = "0 0 * * 0"
+systemSyncScheduler            = "0 0 * * *"
 useTwoFactor                   = true
 upgradeAction                  = InfrastructureGatewayProfileUpgradeAction.NONE
 statsCollectorPort             = 29090L
-
-[InfrastructurePortProfile]
-duplex                         = InfrastructurePortProfileDuplex.FULL
-speed                          = InfrastructurePortProfileSpeed.AUTONEGOTIATE
-mtu                            = 1500L
 
 [L2Domain]
 maintenanceMode                = L2DomainMaintenanceMode.DISABLED
@@ -77,10 +63,6 @@ timeZoneID                     = "UTC"
 
 [EnterpriseNetwork]
 IPType                         = EnterpriseNetworkIPType.IPV4
-
-[NSG]
-configurationReloadState       = "UNKNOWN"
-configurationStatus            = "UNKNOWN"
 
 [PolicyGroup]
 type                           = PolicyGroupType.SOFTWARE


### PR DESCRIPTION
@pdumais, For csharp, java and vro, i only removed the non-existing entities from the default, and changed one conflicting default. However, you might want to decide to do the following for these:
* Remove `InfrastructureGatewayProfile` in its entirety (done so for python & go myself)
* Actually use `DISABLED` for `PATEnabled` on `Domain`, to make it more clear.

Up to you

Please review, @pdumais :)