### PR TITLE
Python vspk bambou2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     name='vspkgenerator',
     packages=find_packages(exclude=['*tests*']),
     include_package_data=True,
-    version='1.4.4',
+    version='1.5.0',
     description='VSPK Generator',
     author='Nuage Networks',
     author_email='opensource@nuagenetworks.net',

--- a/vspkgenerator/vanilla/python/__overrides/nume.override.py
+++ b/vspkgenerator/vanilla/python/__overrides/nume.override.py
@@ -1,3 +1,3 @@
-def save(self, async=False, callback=None):
+def save(self, isasync=False, callback=None):
     """ """
-    super(NUMe, self).save(async=async, callback=callback, encrypted=False)
+    super(NUMe, self).save(isasync=isasync, callback=callback, encrypted=False)

--- a/vspkgenerator/vanilla/python/doc/quickstart.rst
+++ b/vspkgenerator/vanilla/python/doc/quickstart.rst
@@ -272,13 +272,13 @@ To un-assign all the entities, assign an empty list:
 Error handling
 --------------
 
-All of the previous methods raise a ``bambou.exception.BambouHTTPError`` when
+All of the previous methods raise a ``bambou2.exception.BambouHTTPError`` when
 they fail, which contains some interesting information, like the HTTP status
 code. It can be useful to catch these exceptions:
 
 .. code-block:: python
 
-    from bambou.exceptions import BambouHTTPError
+    from bambou2.exceptions import BambouHTTPError
 
     # We assume we have a parent trying to create a child.
 

--- a/vspkgenerator/vanilla/python/requirements.txt
+++ b/vspkgenerator/vanilla/python/requirements.txt
@@ -1,3 +1,3 @@
-bambou>=3.0,<4.0
+bambou2<2.0
 tabulate
 colorama

--- a/vspkgenerator/vanilla/rst/quickstart.rst
+++ b/vspkgenerator/vanilla/rst/quickstart.rst
@@ -272,13 +272,13 @@ To un-assign all the entities, assign an empty list:
 Error handling
 --------------
 
-All of the previous methods raise a ``bambou.exception.BambouHTTPError`` when
+All of the previous methods raise a ``bambou2.exception.BambouHTTPError`` when
 they fail, which contains some interesting information, like the HTTP status
 code. It can be useful to catch these exceptions:
 
 .. code-block:: python
 
-    from bambou.exceptions import BambouHTTPError
+    from bambou2.exceptions import BambouHTTPError
 
     # We assume we have a parent trying to create a child.
 


### PR DESCRIPTION
This is for the 6.0 Nuage timeline where we want to support Python 3.7 and we move to a new nuagenetworks/bambou2 library.

This PR updates Python VSPK generation from monolithe perspective
PR on Monolithe: nuagenetworks/monolithe#123
PR on Bambou2: nuagenetworks/bambou2#1